### PR TITLE
Explicitly add graalvm JS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
 		<!-- camunda and spring use different properties ... -->
 		<java.version>${version.java}</java.version>
-
+		<graalvm.version>21.3.3</graalvm.version>
 	</properties>
 
 	<dependencyManagement>
@@ -147,6 +147,20 @@
 		  <artifactId>cawemo-engine-plugin</artifactId>
 		  <version>1.0.0</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js</artifactId>
+			<version>21.3.3</version>
+			<scope>${graalvm.version}</scope>
+		  </dependency>
+	  
+		  <dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js-scriptengine</artifactId>
+			<version>${graalvm.version}</version>
+			<scope>test</scope>
+		  </dependency>
 		
 	</dependencies>
 


### PR DESCRIPTION
This way you can run the engine on newer versions of Java
See: https://docs.camunda.org/manual/7.17/update/minor/715-to-716/\#java-15-and-graalvm-javascript-support